### PR TITLE
Add draft of spec

### DIFF
--- a/requestStorageAccessForOrigin.bs
+++ b/requestStorageAccessForOrigin.bs
@@ -6,7 +6,7 @@ Status Text: This specification is intended to be merged into the HTML Living St
 Text Macro: LICENSE <a href=https://creativecommons.org/licenses/by/4.0/>Creative Commons Attribution 4.0 International License</a>
 Group: None
 ED: https://github.com/mreichhoff/requestStorageAccessForOrigin
-Status: w3c/UD
+Status: DREAM
 Editor: Matt Reichhoff, w3cid 138889, Google https://google.com, mreichhoff@google.com
 Editor: Johann Hofmann, w3cid 120436, Google https://google.com, johannhof@google.com
 Level: None
@@ -104,8 +104,6 @@ When invoked on {{Document}} |doc| with {{USVString}} |requestedOrigin|, the <df
 <div algorithm>
 To <dfn type="abstract-op">determine if a request has top-level storage access</dfn> with [=request=] |request|, run these steps:
 
-ISSUE: should all cross-site subresource requests behave this way, or only those initiated by the top-level document, or top-level plus those requested from an iframe that is same-site with the top-level document, or only those that have explicitly requested access (in which case a set of requested origins would be maintained)?
-
 1. Let |settings| be |request|'s [=request/client=]'s [=relevant global object=]'s [=relevant settings object=].
 1. Let |embedded origin| be |request|'s [=request/url=]'s [=/origin=].
 1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with {{PermissionDescriptor/name}} set to "<a permission><code>top-level-storage-access</code></a>" and with {{TopLevelStorageAccessPermissionDescriptor/requestedOrigin}} set to |embedded origin|.
@@ -119,7 +117,6 @@ ISSUE: should all cross-site subresource requests behave this way, or only those
 To <dfn type="abstract-op">determine the top-level storage access policy</dfn> for {{TopLevelStorageAccessPermissionDescriptor}} |descriptor|, with {{Document}} |doc|, [=site=] |top-level site|, and {{Promise}} |p|, run these steps:
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |global| be |doc|'s [=relevant global object=].
-<!-- TODO: where to check this, exactly? --> 
 1. Let |existing state| be |descriptor|'s [=permission state=] with |settings|.
 1. If |existing state| is [=permission/granted=]:
     1. [=Queue a global task=] on the [=permission task source=] given |global| to [=resolve=] |p|.
@@ -193,9 +190,7 @@ The requestStorageAccessForOrigin API defines a [=powerful feature=] identified 
 
 <h2 id="fetch-integration">Fetch Integration</h2>
 
-Note that the existing [=environment/obtained storage access flag=] will continue to be used for frame-level access.
-
-ISSUE: export of the flag blocked until merge of https://github.com/privacycg/storage-access/pull/141
+ISSUE(mreichhoff/requestStorageAccessForOrigin#8): Flesh out the exact scope of cookie access.
 
 <div algorithm='cookie-blocking-modification'>
 In [=http network or cache fetch=], when determining whether to block cookies, run the following algorithm. A true result means cookies can be unblocked:
@@ -211,6 +206,8 @@ In [=http network or cache fetch=], when determining whether to block cookies, r
 </div>
 
 <h2 id="storage-access-api-integration">Storage Access API Integration</h2>
+
+ISSUE: This algorithm will need adjustments based on outcome of https://github.com/privacycg/storage-access/pull/141
 
 <div algorithm='storage-access-policy-modification'>
 Modify the [=determine the storage access policy=] algorithm by prepending the following steps:

--- a/requestStorageAccessForOrigin.bs
+++ b/requestStorageAccessForOrigin.bs
@@ -14,7 +14,6 @@ Markup Shorthands: markdown yes, css no
 Complain About: accidental-2119 true
 </pre>
 
-<!-- TODO: evaluate which is needed -->
 <pre class=link-defaults>
 spec:html; type:dfn; for:site; text:same site
 spec:webidl; type:dfn; text:resolve
@@ -123,7 +122,7 @@ To <dfn type="abstract-op">determine the top-level storage access policy</dfn> f
 1. Let |existing state| be |descriptor|'s [=permission state=] with |settings|.
 1. If |existing state| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
 1. If |existing state| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
-1. Assert that document's browsing context is a top-level browsing context.
+1. Assert that |doc|'s [=Document/browsing context=] is a [=top-level browsing context=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |settings|'s [=environment settings object/origin=].
 1. Let |embeddee opt-in| be the result of running an [=implementation-defined=] set of steps to determine if |descriptor|'s <code>requestedOrigin</origin> opts into sharing on |top-level site|.
@@ -183,8 +182,10 @@ In [=http network or cache fetch=], when determining whether to block cookies, r
 1. Let |has top-level access| be the result of running [=determine if a request has top-level storage access=] on |request|.
 1. If |has top-level access| is false, return false.
 1. Let |is subresource| be true if |request| is a [=subresource request=] and false otherwise.
-1. Let |allowed subresource mode| be true if |request|'s [=request/mode=] is "cors" and false otherwise.
+1. Let |allowed subresource mode| be true if |request|'s [=request/mode=] is "cors" and |request|'s [=request/credentials mode=] is "include", and false otherwise.
 1. If |is subresource| is true and |allowed subresource mode| is false, return false.
+<!-- TODO: this call chain is dubious...it may not be possible to reach into the browsing context like this -->
+1. If |request|'s [=request/client=]'s [=relevant global object=]'s [=associated document=]'s [=Document/browsing context=] is not a [=top-level browsing context=], return false.
 1. Return true.
 
 <h2 id="storage-access-api-integration">Storage Access API Integration</h2>

--- a/requestStorageAccessForOrigin.bs
+++ b/requestStorageAccessForOrigin.bs
@@ -1,0 +1,212 @@
+<pre class="metadata">
+Title: requestStorageAccessForOrigin API
+Shortname: top-level-storage-access-api
+Abstract: The requestStorageAccessForOrigin API allows top-level sites to request access to cross-site cookies on behalf of embedded origins.
+Status Text: This specification is intended to be merged into the HTML Living Standard. It is neither a WHATWG Living Standard nor is it on the standards track at W3C.
+Text Macro: LICENSE <a href=https://creativecommons.org/licenses/by/4.0/>Creative Commons Attribution 4.0 International License</a>
+Group: privacycg
+ED: https://github.com/mreichhoff/requestStorageAccessForOrigin
+Status: CG-DRAFT
+Editor: Matt Reichhoff, w3cid 138889, Google https://google.com, mreichhoff@google.com
+Editor: Johann Hofmann, w3cid 120436, Google https://google.com, johannhof@google.com
+Level: None
+Markup Shorthands: markdown yes, css no
+Complain About: accidental-2119 true
+</pre>
+
+<!-- TODO: evaluate which is needed -->
+<pre class=link-defaults>
+spec:html; type:dfn; for:site; text:same site
+spec:webidl; type:dfn; text:resolve
+</pre>
+
+<pre class="anchors">
+urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
+    text: agent cluster; url: #sec-agent-clusters; type: dfn
+urlPrefix: https://infra.spec.whatwg.org/; spec: INFRA
+    text: implementation-defined; url: #implementation-defined; type: dfn
+urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
+    type: dfn
+        text: current browsing context; url: dfn-current-browsing-context
+        text: WebDriver error; url: dfn-error
+        text: WebDriver error code; url: dfn-error-code
+        text: extension command; url: dfn-extension-commands
+        text: extension command URI template; url: dfn-extension-command-uri-template
+        text: getting a property; url: dfn-getting-properties
+        text: invalid argument; url: dfn-invalid-argument
+        text: local end; url: dfn-local-end
+        text: remote end steps; url: dfn-remote-end-steps
+        text: unknown error; url: dfn-unknown-error
+        text: unsupported operation; url: dfn-unsupported-operation
+        text: session; url: dfn-session
+        text: success; url: dfn-success
+urlPrefix: https://privacycg.github.io/storage-access/#; spec: storage-access
+    type: dfn
+        text: determine the storage access policy; url: determine-the-storage-access-policy
+        text: determine if a site has storage access; url: determine-if-a-site-has-storage-access
+urlPrefix: https://fetch.spec.whatwg.org/#; spec: fetch
+    type: dfn
+        text: http network or cache fetch; url: http-network-or-cache-fetch
+        text: request; url: concept-request
+</pre>
+
+<section class="non-normative">
+<h2 id="intro">Introduction</h2>
+
+<em>This section is non-normative.</em>
+
+Many User Agents prevent content from accessing non-[=same site=] data stored in cookies. 
+This can break embedded content which relies on having access to non-[=same site=] cookies.
+
+The requestStorageAccessForOrigin API enables developers to request access to non-[=same site=] cookies for embedded resources such as iframes, scripts, or images.
+It accomplishes this by specifying {{Document/requestStorageAccessForOrigin(origin)}}, which allows top-level browsing contexts to request access
+to unpartitioned cookies on behalf of another [=url/origin=].
+
+</section>
+
+<h2 id="infra">Infrastructure</h2>
+
+This specification depends on the Infra standard. [[!INFRA]]
+
+<h2 id="the-rsa-for-api">The requestStorageAccessForOrigin API</h2>
+
+This specification defines a method that can be used to request access to [=unpartitioned data=] on behalf of another [=url/origin=] ({{Document/requestStorageAccessForOrigin(origin)}}).
+
+<div class=example>
+
+Alex visits `https://social.example/`. The page sets a cookie. This cookie has been set in a [=first-party-site context=].
+
+Later on, Alex visits `https://video.example/`, which has an <{img}> in it which loads `https://social.example/profile-image`. In this case, the `social.example` {{Document}} |doc| is in a [=third party context=], and the cookie set previously might or might not be visible from |doc|`.`{{Document/cookie}}, depending on User Agent storage access policies.
+
+A script on `https://video.example/` could request access on behalf of `https://social.example` by calling |doc|`.`{{Document/requestStorageAccessForOrigin(origin)}} with {{USVString}} |origin| as `https://social.example`.
+
+</div>
+
+<dfn>Unpartitioned data</dfn> is client-side storage that would be available to a [=site=] were it loaded in a [=first-party-site context=].
+
+A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active document=] of a [=top-level browsing context=]. Otherwise, it is in a [=first-party-site context=] if it is an [=active document=] and the [=environment settings object/origin=] and [=top-level origin=] of its [=relevant settings object=] are [=same site=] with one another.
+
+A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
+
+<h3 id="the-document-object">Changes to {{Document}}</h3>
+
+<pre class="idl">
+partial interface Document {
+  Promise&lt;undefined> requestStorageAccessForOrigin(USVString origin);
+};
+</pre>
+
+When invoked on {{Document}} |doc| with {{USVString}} |requestedOrigin|, the <dfn export method for=Document><code>requestStorageAccessForOrigin(requestedOrigin)</code></dfn> method must run these steps:
+
+1. Let |p| be [=a new promise=].
+1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. Let |parsedURL| be the the result of running the [=URL parser=] on |requestedOrigin|.
+1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
+1. Let |origin| be |parsedURL|'s [=url/origin=].
+1. If |origin| is an [=opaque origin=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If |doc|'s [=Document/origin=] is [=same origin=] with |origin|, [=/resolve=] and return |p|.
+1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |origin|.
+1. Let |global| be |doc|'s [=relevant global object=].
+1. Run these steps [=in parallel=]:
+    1. Let |hasAccess| be [=a new promise=].
+    1. [=Determine the top-level storage access policy=] with |descriptor|, |doc| and |hasAccess|.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to resolve or reject |p| based on the result of |hasAccess|.
+1. Return |p|.
+
+<h3 id="ua-policies">User Agent top-level storage access policies</h3>
+
+To <dfn type="abstract-op">determine if a request has top-level storage access</dfn> with [=request=] |request|, run these steps:
+
+ISSUE: should all cross-site subresource requests behave this way, or only those initiated by the top-level document, or top-level plus those requested from an iframe that is same-site with the top-level document, or only those that have explicitly requested access (in which case a set of requested origins would be maintained)?
+
+<!-- this long chain pulled from fetch, but may be unusual or unsafe -->
+1. Let |settings| be |request|'s [=request/client=]'s [=relevant global object=]'s [=associated document=]'s [=relevant settings object=].
+1. Let |embedded origin| be |request|'s [=request/url=].
+1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |embedded origin|.
+1. Let |existing state| be the result of checking |descriptor|'s [=permission state=] with |settings|.
+1. If |existing state| is [=permission/granted=], return true.
+1. Return false.
+
+To <dfn type="abstract-op">determine the top-level storage access policy</dfn> for {{TopLevelStorageAccessPermissionDescriptor}} |descriptor|, with {{Document}} |doc| and {{Promise}} |p|, run these steps:
+1. Let |settings| be |doc|'s [=relevant settings object=].
+<!-- TODO: where to check this, exactly? --> 
+1. Let |existing state| be the result of checking |descriptor|'s [=permission state=] with |settings|.
+1. If |existing state| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
+1. If |existing state| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+<!-- note that this assumes |doc| is top-level. -->
+1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |settings|'s [=environment settings object/origin=].
+1. Let |embeddee opt-in| be the result of running an [=implementation-defined=] set of steps to determine if |descriptor|'s <code>requestedOrigin</origin> opts into sharing on |top-level site|.
+1. If |embeddee opt-in| is false, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
+1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |top-level site|'s request for |descriptor|'s <code>requestedOrigin</code> should be granted or denied without prompting the user.
+1. Let |global| be |doc|'s [=relevant global object=].
+1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
+1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
+1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>top-level-storage-access</code></a>" with |descriptor|.
+1. If |permissionState| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
+1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
+1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+
+<h2 id="permissions-integration">Permissions Integration</h2>
+
+ISSUE: blocked until merge of https://github.com/w3c/permissions/pull/390
+
+The requestStorageAccessForOrigin API defines a [=powerful feature=] identified by the [=powerful feature/name=] "<dfn export permission><code>top-level-storage-access</code></dfn>". It defines the following permission-related algorithms:
+
+<dl>
+  <dt>{{PermissionDescriptor}}</dt>
+  <dd>
+    The "<a permission><code>top-level-storage-access</code></a>" [=powerful feature=] defines a {{PermissionDescriptor}} as follows:
+    <pre class="idl">
+        dictionary TopLevelStorageAccessPermissionDescriptor : PermissionDescriptor {
+            USVString requestedOrigin = "";
+        };
+    </pre>
+  </dd>
+  <dt>[=powerful feature/permission query algorithm=]</dt>
+  <dd>
+    To query the "<a permission><code>top-level-storage-access</code></a>" permission, given a {{PermissionDescriptor}} |permissionDesc| and a {{PermissionStatus}} |status|, run the following steps:
+
+    1. Set |status|'s {{PermissionStatus/state}} to |permissionDesc|'s [=permission state=].
+    1. If |status|'s {{PermissionStatus/state}} is [=permission/denied=], set |status|'s {{PermissionStatus/state}} to [=permission/prompt=].
+
+        Note: The [=permission/denied=] permission state is not revealed to avoid exposing the user's decision to developers. This is done to prevent retaliation against the user and repeated prompting to the detriment of the user experience.
+  </dd>
+  <dt>[=powerful feature/permission key generation algorithm=]</dt>
+  <dd>
+    To generate a new [=permission store key=] for the "<a permission><code>top-level-storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
+    1. Return the result of [=obtain a site|obtaining a site=] from |settings|' [=top-level origin=].
+  </dd>
+</dl>
+
+<h2 id="fetch-integration">Fetch Integration</h2>
+
+Note that the existing [=environment/obtained storage access flag=] will continue to be used for frame-level access.
+
+ISSUE: export of the flag blocked until merge of https://github.com/privacycg/storage-access/pull/141
+
+In [=http network or cache fetch=], when determining whether to block cookies, run the following algorithm. A true result means cookies can be unblocked:
+1. Let |has top-level access| be the result of running [=determine if a request has top-level storage access=] on |request|.
+1. If |has top-level access| is false, return false.
+1. Let |is subresource| be true if |request| is a [=subresource request=] and false otherwise.
+1. Let |allowed subresource mode| be true if |request|'s [=request/mode=] is "cors" and false otherwise.
+1. If |is subresource| is true and |allowed subresource mode| is false, return false.
+1. Return true.
+
+<h2 id="storage-access-api-integration">Storage Access API Integration</h2>
+Modify the [=determine the storage access policy=] algorithm by prepending the following steps:
+1. Let |settings| be |doc|'s [=relevant settings object=].
+1. Let |origin| be |settings|' [=environment settings object/origin=].
+1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |origin|.
+1. If |descriptor|'s [=permission state=] is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
+1. If |descriptor|'s [=permission state=] is [=permission/denied=], [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return.
+
+<h2 id="privacy">Privacy considerations</h2>
+
+ISSUE: Write this section.
+
+<h2 id="security">Security considerations</h2>
+
+ISSUE: Write this section.

--- a/requestStorageAccessForOrigin.bs
+++ b/requestStorageAccessForOrigin.bs
@@ -95,7 +95,8 @@ When invoked on {{Document}} |doc| with {{USVString}} |requestedOrigin|, the <df
 1. Let |global| be |doc|'s [=relevant global object=].
 1. Run these steps [=in parallel=]:
     1. Let |hasAccess| be [=a new promise=].
-    1. [=Determine the top-level storage access policy=] with |descriptor|, |doc|, and |hasAccess|.
+    1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=relevant settings object=]'s [=environment settings object/origin=].
+    1. [=Determine the top-level storage access policy=] with |descriptor|, |doc|, |top-level site|, and |hasAccess|.
     1. [=Queue a global task=] on the [=permission task source=] given |global| to resolve or reject |p| based on the result of |hasAccess|.
 1. Return |p|.
 
@@ -113,7 +114,7 @@ ISSUE: should all cross-site subresource requests behave this way, or only those
 1. If |existing state| is [=permission/granted=], return true.
 1. Return false.
 
-To <dfn type="abstract-op">determine the top-level storage access policy</dfn> for {{TopLevelStorageAccessPermissionDescriptor}} |descriptor|, with {{Document}} |doc| and {{Promise}} |p|, run these steps:
+To <dfn type="abstract-op">determine the top-level storage access policy</dfn> for {{TopLevelStorageAccessPermissionDescriptor}} |descriptor|, with {{Document}} |doc|, [=site=] |top-level site|, and {{Promise}} |p|, run these steps:
 1. Let |settings| be |doc|'s [=relevant settings object=].
 <!-- TODO: where to check this, exactly? --> 
 1. Let |existing state| be |descriptor|'s [=permission state=] with |settings|.
@@ -127,13 +128,11 @@ To <dfn type="abstract-op">determine the top-level storage access policy</dfn> f
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=]:
     1. [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}}.
     1. Return.
-1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |settings|'s [=environment settings object/origin=].
 1. Let |embeddee opt-in| be the result of running an [=implementation-defined=] set of steps to determine if |descriptor|'s <code>requestedOrigin</origin> opts into sharing on |top-level site|.
 1. If |embeddee opt-in| is false:
     1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Return.
 1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |top-level site|'s request for |descriptor|'s <code>requestedOrigin</code> should be granted or denied without prompting the user.
-1. Let |global| be |doc|'s [=relevant global object=].
 1. If |implicitly granted| is true:
     1. [=resolve=] |p|.
     1. Return.

--- a/requestStorageAccessForOrigin.bs
+++ b/requestStorageAccessForOrigin.bs
@@ -15,7 +15,6 @@ Complain About: accidental-2119 true
 </pre>
 
 <pre class=link-defaults>
-spec:html; type:dfn; for:/; text:origin
 spec:html; type:dfn; for:/; text:traversable navigable
 spec:html; type:dfn; for:site; text:same site
 spec:webidl; type:dfn; text:resolve
@@ -44,7 +43,7 @@ This can break embedded content which relies on having access to non-[=same site
 
 The requestStorageAccessForOrigin API enables developers to request access to non-[=same site=] cookies for embedded resources such as iframes, scripts, or images.
 It accomplishes this by specifying {{Document/requestStorageAccessForOrigin(origin)}}, which allows [=traversable navigable=]s to request access
-to unpartitioned cookies on behalf of another [=origin=].
+to unpartitioned cookies on behalf of another [=/origin=].
 
 </section>
 
@@ -54,7 +53,7 @@ This specification depends on the Infra standard. [[!INFRA]]
 
 <h2 id="the-rsa-for-api">The requestStorageAccessForOrigin API</h2>
 
-This specification defines a method that can be used to request access to [=unpartitioned data=] on behalf of another [=origin=] ({{Document/requestStorageAccessForOrigin(origin)}}).
+This specification defines a method that can be used to request access to [=unpartitioned data=] on behalf of another [=/origin=] ({{Document/requestStorageAccessForOrigin(origin)}}).
 
 <div class=example>
 
@@ -80,6 +79,7 @@ partial interface Document {
 };
 </pre>
 
+<div algorithm>
 When invoked on {{Document}} |doc| with {{USVString}} |requestedOrigin|, the <dfn export method for=Document><code>requestStorageAccessForOrigin(requestedOrigin)</code></dfn> method must run these steps:
 
 1. Let |p| be [=a new promise=].
@@ -88,63 +88,68 @@ When invoked on {{Document}} |doc| with {{USVString}} |requestedOrigin|, the <df
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |requestedOrigin|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
-1. Let |origin| be |parsedURL|'s [=origin=].
+1. Let |origin| be |parsedURL|'s [=/origin=].
 1. If |origin| is an [=opaque origin=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is [=same origin=] with |origin|, [=resolve=] and return |p|.
-1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |origin|.
-1. Let |global| be |doc|'s [=relevant global object=].
+1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with {{PermissionDescriptor/name}} set to "<a permission><code>top-level-storage-access</code></a>" and with {{TopLevelStorageAccessPermissionDescriptor/requestedOrigin}} set to |origin|.
 1. Run these steps [=in parallel=]:
-    1. Let |hasAccess| be [=a new promise=].
     1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=relevant settings object=]'s [=environment settings object/origin=].
-    1. [=Determine the top-level storage access policy=] with |descriptor|, |doc|, |top-level site|, and |hasAccess|.
-    1. [=Queue a global task=] on the [=permission task source=] given |global| to resolve or reject |p| based on the result of |hasAccess|.
+    1. [=Determine the top-level storage access policy=] with |descriptor|, |doc|, |top-level site|, and |p|.
 1. Return |p|.
+
+</div>
 
 <h3 id="ua-policies">User Agent top-level storage access policies</h3>
 
+<div algorithm>
 To <dfn type="abstract-op">determine if a request has top-level storage access</dfn> with [=request=] |request|, run these steps:
 
 ISSUE: should all cross-site subresource requests behave this way, or only those initiated by the top-level document, or top-level plus those requested from an iframe that is same-site with the top-level document, or only those that have explicitly requested access (in which case a set of requested origins would be maintained)?
 
-<!-- this long chain pulled from fetch, but may be unusual or unsafe -->
-1. Let |settings| be |request|'s [=request/client=]'s [=relevant global object=]'s [=associated document=]'s [=relevant settings object=].
-1. Let |embedded origin| be |request|'s [=request/url=].
-1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |embedded origin|.
+1. Let |settings| be |request|'s [=request/client=]'s [=relevant global object=]'s [=relevant settings object=].
+1. Let |embedded origin| be |request|'s [=request/url=]'s [=/origin=].
+1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with {{PermissionDescriptor/name}} set to "<a permission><code>top-level-storage-access</code></a>" and with {{TopLevelStorageAccessPermissionDescriptor/requestedOrigin}} set to |embedded origin|.
 1. Let |existing state| be |descriptor|'s [=permission state=] with |settings|.
 1. If |existing state| is [=permission/granted=], return true.
 1. Return false.
 
+</div>
+
+<div algorithm>
 To <dfn type="abstract-op">determine the top-level storage access policy</dfn> for {{TopLevelStorageAccessPermissionDescriptor}} |descriptor|, with {{Document}} |doc|, [=site=] |top-level site|, and {{Promise}} |p|, run these steps:
 1. Let |settings| be |doc|'s [=relevant settings object=].
+1. Let |global| be |doc|'s [=relevant global object=].
 <!-- TODO: where to check this, exactly? --> 
 1. Let |existing state| be |descriptor|'s [=permission state=] with |settings|.
 1. If |existing state| is [=permission/granted=]:
-    1. [=resolve=] |p|
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=resolve=] |p|.
     1. Return.
 1. If |existing state| is [=permission/denied=]:
-    1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Return.
 1. Assert that |doc|'s [=node navigable=] is a [=traversable navigable=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=]:
-    1. [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}}.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=reject=] |p| with a n "{{InvalidStateError}}" {{DOMException}}.
     1. Return.
-1. Let |embeddee opt-in| be the result of running an [=implementation-defined=] set of steps to determine if |descriptor|'s <code>requestedOrigin</origin> opts into sharing on |top-level site|.
+1. Let |embeddee opt-in| be the result of running an [=implementation-defined=] set of steps to determine if |descriptor|'s {{TopLevelStorageAccessPermissionDescriptor/requestedOrigin}} opts into sharing on |top-level site|.
 1. If |embeddee opt-in| is false:
-    1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Return.
-1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |top-level site|'s request for |descriptor|'s <code>requestedOrigin</code> should be granted or denied without prompting the user.
+1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |top-level site|'s request for |descriptor|'s {{TopLevelStorageAccessPermissionDescriptor/requestedOrigin}} should be granted or denied without prompting the user.
 1. If |implicitly granted| is true:
-    1. [=resolve=] |p|.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=resolve=] |p|.
     1. Return.
 1. If |implicitly denied| is true:
     1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Return.
 1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>top-level-storage-access</code></a>" with |descriptor|.
 1. If |permissionState| is [=permission/granted=]:
-    1. [=resolve=] |p|.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=resolve=] |p|.
     1. Return.
 1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
-1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+1. [=Queue a global task=] on the [=permission task source=] given |global| to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+
+</div>
 
 <h2 id="permissions-integration">Permissions Integration</h2>
 
@@ -162,21 +167,27 @@ The requestStorageAccessForOrigin API defines a [=powerful feature=] identified 
   </dd>
   <dt>[=powerful feature/permission query algorithm=]</dt>
   <dd>
+    <div algorithm='top-level-storage-access-query'>
     To query the "<a permission><code>top-level-storage-access</code></a>" permission, given a {{PermissionDescriptor}} |permissionDesc| and a {{PermissionStatus}} |status|, run the following steps:
 
     1. Set |status|'s {{PermissionStatus/state}} to |permissionDesc|'s [=permission state=].
     1. If |status|'s {{PermissionStatus/state}} is [=permission/denied=], set |status|'s {{PermissionStatus/state}} to [=permission/prompt=].
 
         Note: The [=permission/denied=] permission state is not revealed to avoid exposing the user's decision to developers. This is done to prevent retaliation against the user and repeated prompting to the detriment of the user experience.
+
+    </div>
   </dd>
-    <dt>[=powerful feature/permission key type=]</dt>
+  <dt>[=powerful feature/permission key type=]</dt>
   <dd>
-    A [=permission key] of the "<a permission><code>top-level-storage-access</code></a>" feature has the type [=site=].
+    A [=permission key=] of the "<a permission><code>top-level-storage-access</code></a>" feature has the type [=site=].
   </dd>
   <dt>[=powerful feature/permission key generation algorithm=]</dt>
   <dd>
+    <div algorithm='top-level-storage-access-key-generation'>
     To generate a new [=permission key=] for the "<a permission><code>top-level-storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
     1. Return the result of [=obtain a site|obtaining a site=] from |settings|' [=top-level origin=].
+
+    </div>
   </dd>
 </dl>
 
@@ -186,6 +197,7 @@ Note that the existing [=environment/obtained storage access flag=] will continu
 
 ISSUE: export of the flag blocked until merge of https://github.com/privacycg/storage-access/pull/141
 
+<div algorithm='cookie-blocking-modification'>
 In [=http network or cache fetch=], when determining whether to block cookies, run the following algorithm. A true result means cookies can be unblocked:
 1. Let |has top-level access| be the result of running [=determine if a request has top-level storage access=] on |request|.
 1. If |has top-level access| is false, return false.
@@ -196,13 +208,19 @@ In [=http network or cache fetch=], when determining whether to block cookies, r
 1. If |request|'s [=request/client=]'s [=relevant global object=]'s [=associated document=] is not a [=traversable navigable=], return false.
 1. Return true.
 
+</div>
+
 <h2 id="storage-access-api-integration">Storage Access API Integration</h2>
+
+<div algorithm='storage-access-policy-modification'>
 Modify the [=determine the storage access policy=] algorithm by prepending the following steps:
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |origin| be |settings|' [=environment settings object/origin=].
-1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |origin|.
+1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with {{PermissionDescriptor/name}} set to "<a permission><code>top-level-storage-access</code></a>" and with {{TopLevelStorageAccessPermissionDescriptor/requestedOrigin}} set to |origin|.
 1. If |descriptor|'s [=permission state=] is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=resolve=] |p|, and return.
 1. If |descriptor|'s [=permission state=] is [=permission/denied=], [=queue a global task=] on the [=permission task source=] given |global| to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return.
+
+</div>
 
 <h2 id="privacy">Privacy considerations</h2>
 

--- a/requestStorageAccessForOrigin.bs
+++ b/requestStorageAccessForOrigin.bs
@@ -1,12 +1,12 @@
 <pre class="metadata">
 Title: requestStorageAccessForOrigin API
-Shortname: top-level-storage-access-api
+Shortname: storage-access-for-origin
 Abstract: The requestStorageAccessForOrigin API allows top-level sites to request access to cross-site cookies on behalf of embedded origins.
 Status Text: This specification is intended to be merged into the HTML Living Standard. It is neither a WHATWG Living Standard nor is it on the standards track at W3C.
 Text Macro: LICENSE <a href=https://creativecommons.org/licenses/by/4.0/>Creative Commons Attribution 4.0 International License</a>
-Group: privacycg
+Group: None
 ED: https://github.com/mreichhoff/requestStorageAccessForOrigin
-Status: CG-DRAFT
+Status: w3c/UD
 Editor: Matt Reichhoff, w3cid 138889, Google https://google.com, mreichhoff@google.com
 Editor: Johann Hofmann, w3cid 120436, Google https://google.com, johannhof@google.com
 Level: None
@@ -21,25 +21,13 @@ spec:webidl; type:dfn; text:resolve
 </pre>
 
 <pre class="anchors">
+urlPrefix: https://url.spec.whatwg.org/; spec:url;
+    type:dfn
+        text:origin
 urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: agent cluster; url: #sec-agent-clusters; type: dfn
 urlPrefix: https://infra.spec.whatwg.org/; spec: INFRA
     text: implementation-defined; url: #implementation-defined; type: dfn
-urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
-    type: dfn
-        text: current browsing context; url: dfn-current-browsing-context
-        text: WebDriver error; url: dfn-error
-        text: WebDriver error code; url: dfn-error-code
-        text: extension command; url: dfn-extension-commands
-        text: extension command URI template; url: dfn-extension-command-uri-template
-        text: getting a property; url: dfn-getting-properties
-        text: invalid argument; url: dfn-invalid-argument
-        text: local end; url: dfn-local-end
-        text: remote end steps; url: dfn-remote-end-steps
-        text: unknown error; url: dfn-unknown-error
-        text: unsupported operation; url: dfn-unsupported-operation
-        text: session; url: dfn-session
-        text: success; url: dfn-success
 urlPrefix: https://privacycg.github.io/storage-access/#; spec: storage-access
     type: dfn
         text: determine the storage access policy; url: determine-the-storage-access-policy
@@ -60,7 +48,7 @@ This can break embedded content which relies on having access to non-[=same site
 
 The requestStorageAccessForOrigin API enables developers to request access to non-[=same site=] cookies for embedded resources such as iframes, scripts, or images.
 It accomplishes this by specifying {{Document/requestStorageAccessForOrigin(origin)}}, which allows top-level browsing contexts to request access
-to unpartitioned cookies on behalf of another [=url/origin=].
+to unpartitioned cookies on behalf of another [=origin=].
 
 </section>
 
@@ -70,7 +58,7 @@ This specification depends on the Infra standard. [[!INFRA]]
 
 <h2 id="the-rsa-for-api">The requestStorageAccessForOrigin API</h2>
 
-This specification defines a method that can be used to request access to [=unpartitioned data=] on behalf of another [=url/origin=] ({{Document/requestStorageAccessForOrigin(origin)}}).
+This specification defines a method that can be used to request access to [=unpartitioned data=] on behalf of another [=origin=] ({{Document/requestStorageAccessForOrigin(origin)}}).
 
 <div class=example>
 
@@ -100,12 +88,11 @@ When invoked on {{Document}} |doc| with {{USVString}} |requestedOrigin|, the <df
 
 1. Let |p| be [=a new promise=].
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
-1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |requestedOrigin|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
-1. Let |origin| be |parsedURL|'s [=url/origin=].
+1. Let |origin| be |parsedURL|'s [=origin=].
 1. If |origin| is an [=opaque origin=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is [=same origin=] with |origin|, [=/resolve=] and return |p|.
 1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |origin|.
@@ -126,17 +113,18 @@ ISSUE: should all cross-site subresource requests behave this way, or only those
 1. Let |settings| be |request|'s [=request/client=]'s [=relevant global object=]'s [=associated document=]'s [=relevant settings object=].
 1. Let |embedded origin| be |request|'s [=request/url=].
 1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |embedded origin|.
-1. Let |existing state| be the result of checking |descriptor|'s [=permission state=] with |settings|.
+1. Let |existing state| be |descriptor|'s [=permission state=] with |settings|.
 1. If |existing state| is [=permission/granted=], return true.
 1. Return false.
 
 To <dfn type="abstract-op">determine the top-level storage access policy</dfn> for {{TopLevelStorageAccessPermissionDescriptor}} |descriptor|, with {{Document}} |doc| and {{Promise}} |p|, run these steps:
 1. Let |settings| be |doc|'s [=relevant settings object=].
 <!-- TODO: where to check this, exactly? --> 
-1. Let |existing state| be the result of checking |descriptor|'s [=permission state=] with |settings|.
+1. Let |existing state| be |descriptor|'s [=permission state=] with |settings|.
 1. If |existing state| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
 1. If |existing state| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
-<!-- note that this assumes |doc| is top-level. -->
+1. Assert that document's browsing context is a top-level browsing context.
+1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |settings|'s [=environment settings object/origin=].
 1. Let |embeddee opt-in| be the result of running an [=implementation-defined=] set of steps to determine if |descriptor|'s <code>requestedOrigin</origin> opts into sharing on |top-level site|.
 1. If |embeddee opt-in| is false, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
@@ -174,9 +162,13 @@ The requestStorageAccessForOrigin API defines a [=powerful feature=] identified 
 
         Note: The [=permission/denied=] permission state is not revealed to avoid exposing the user's decision to developers. This is done to prevent retaliation against the user and repeated prompting to the detriment of the user experience.
   </dd>
+    <dt>[=powerful feature/permission key type=]</dt>
+  <dd>
+    A [=permission key] of the "<a permission><code>top-level-storage-access</code></a>" feature has the type [=site=].
+  </dd>
   <dt>[=powerful feature/permission key generation algorithm=]</dt>
   <dd>
-    To generate a new [=permission store key=] for the "<a permission><code>top-level-storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
+    To generate a new [=permission key=] for the "<a permission><code>top-level-storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
     1. Return the result of [=obtain a site|obtaining a site=] from |settings|' [=top-level origin=].
   </dd>
 </dl>

--- a/requestStorageAccessForOrigin.bs
+++ b/requestStorageAccessForOrigin.bs
@@ -138,8 +138,6 @@ To <dfn type="abstract-op">determine the top-level storage access policy</dfn> f
 
 <h2 id="permissions-integration">Permissions Integration</h2>
 
-ISSUE: blocked until merge of https://github.com/w3c/permissions/pull/390
-
 The requestStorageAccessForOrigin API defines a [=powerful feature=] identified by the [=powerful feature/name=] "<dfn export permission><code>top-level-storage-access</code></dfn>". It defines the following permission-related algorithms:
 
 <dl>

--- a/requestStorageAccessForOrigin.bs
+++ b/requestStorageAccessForOrigin.bs
@@ -15,18 +15,16 @@ Complain About: accidental-2119 true
 </pre>
 
 <pre class=link-defaults>
+spec:html; type:dfn; for:/; text:origin
+spec:html; type:dfn; for:/; text:traversable navigable
 spec:html; type:dfn; for:site; text:same site
 spec:webidl; type:dfn; text:resolve
+spec:fetch; type:dfn; for:/; text:request
 </pre>
 
 <pre class="anchors">
-urlPrefix: https://url.spec.whatwg.org/; spec:url;
-    type:dfn
-        text:origin
 urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     text: agent cluster; url: #sec-agent-clusters; type: dfn
-urlPrefix: https://infra.spec.whatwg.org/; spec: INFRA
-    text: implementation-defined; url: #implementation-defined; type: dfn
 urlPrefix: https://privacycg.github.io/storage-access/#; spec: storage-access
     type: dfn
         text: determine the storage access policy; url: determine-the-storage-access-policy
@@ -34,7 +32,6 @@ urlPrefix: https://privacycg.github.io/storage-access/#; spec: storage-access
 urlPrefix: https://fetch.spec.whatwg.org/#; spec: fetch
     type: dfn
         text: http network or cache fetch; url: http-network-or-cache-fetch
-        text: request; url: concept-request
 </pre>
 
 <section class="non-normative">
@@ -46,7 +43,7 @@ Many User Agents prevent content from accessing non-[=same site=] data stored in
 This can break embedded content which relies on having access to non-[=same site=] cookies.
 
 The requestStorageAccessForOrigin API enables developers to request access to non-[=same site=] cookies for embedded resources such as iframes, scripts, or images.
-It accomplishes this by specifying {{Document/requestStorageAccessForOrigin(origin)}}, which allows top-level browsing contexts to request access
+It accomplishes this by specifying {{Document/requestStorageAccessForOrigin(origin)}}, which allows [=traversable navigable=]s to request access
 to unpartitioned cookies on behalf of another [=origin=].
 
 </section>
@@ -71,7 +68,7 @@ A script on `https://video.example/` could request access on behalf of `https://
 
 <dfn>Unpartitioned data</dfn> is client-side storage that would be available to a [=site=] were it loaded in a [=first-party-site context=].
 
-A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active document=] of a [=top-level browsing context=]. Otherwise, it is in a [=first-party-site context=] if it is an [=active document=] and the [=environment settings object/origin=] and [=top-level origin=] of its [=relevant settings object=] are [=same site=] with one another.
+A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active document=] of a [=traversable navigable=]. Otherwise, it is in a [=first-party-site context=] if it is an [=active document=] and the [=environment settings object/origin=] and [=top-level origin=] of its [=relevant settings object=] are [=same site=] with one another.
 
 A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
@@ -87,18 +84,18 @@ When invoked on {{Document}} |doc| with {{USVString}} |requestedOrigin|, the <df
 
 1. Let |p| be [=a new promise=].
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If |doc|'s [=node navigable=] is not a [=traversable navigable=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |requestedOrigin|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |origin| be |parsedURL|'s [=origin=].
 1. If |origin| is an [=opaque origin=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/origin=] is [=same origin=] with |origin|, [=/resolve=] and return |p|.
+1. If |doc|'s [=Document/origin=] is [=same origin=] with |origin|, [=resolve=] and return |p|.
 1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |origin|.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. Run these steps [=in parallel=]:
     1. Let |hasAccess| be [=a new promise=].
-    1. [=Determine the top-level storage access policy=] with |descriptor|, |doc| and |hasAccess|.
+    1. [=Determine the top-level storage access policy=] with |descriptor|, |doc|, and |hasAccess|.
     1. [=Queue a global task=] on the [=permission task source=] given |global| to resolve or reject |p| based on the result of |hasAccess|.
 1. Return |p|.
 
@@ -120,21 +117,35 @@ To <dfn type="abstract-op">determine the top-level storage access policy</dfn> f
 1. Let |settings| be |doc|'s [=relevant settings object=].
 <!-- TODO: where to check this, exactly? --> 
 1. Let |existing state| be |descriptor|'s [=permission state=] with |settings|.
-1. If |existing state| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
-1. If |existing state| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
-1. Assert that |doc|'s [=Document/browsing context=] is a [=top-level browsing context=].
-1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If |existing state| is [=permission/granted=]:
+    1. [=resolve=] |p|
+    1. Return.
+1. If |existing state| is [=permission/denied=]:
+    1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+    1. Return.
+1. Assert that |doc|'s [=node navigable=] is a [=traversable navigable=].
+1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=]:
+    1. [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}}.
+    1. Return.
 1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |settings|'s [=environment settings object/origin=].
 1. Let |embeddee opt-in| be the result of running an [=implementation-defined=] set of steps to determine if |descriptor|'s <code>requestedOrigin</origin> opts into sharing on |top-level site|.
-1. If |embeddee opt-in| is false, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
+1. If |embeddee opt-in| is false:
+    1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+    1. Return.
 1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |top-level site|'s request for |descriptor|'s <code>requestedOrigin</code> should be granted or denied without prompting the user.
 1. Let |global| be |doc|'s [=relevant global object=].
-1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
-1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
+1. If |implicitly granted| is true:
+    1. [=resolve=] |p|.
+    1. Return.
+1. If |implicitly denied| is true:
+    1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+    1. Return.
 1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>top-level-storage-access</code></a>" with |descriptor|.
-1. If |permissionState| is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
+1. If |permissionState| is [=permission/granted=]:
+    1. [=resolve=] |p|.
+    1. Return.
 1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
-1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+1. [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 
 <h2 id="permissions-integration">Permissions Integration</h2>
 
@@ -183,7 +194,7 @@ In [=http network or cache fetch=], when determining whether to block cookies, r
 1. Let |allowed subresource mode| be true if |request|'s [=request/mode=] is "cors" and |request|'s [=request/credentials mode=] is "include", and false otherwise.
 1. If |is subresource| is true and |allowed subresource mode| is false, return false.
 <!-- TODO: this call chain is dubious...it may not be possible to reach into the browsing context like this -->
-1. If |request|'s [=request/client=]'s [=relevant global object=]'s [=associated document=]'s [=Document/browsing context=] is not a [=top-level browsing context=], return false.
+1. If |request|'s [=request/client=]'s [=relevant global object=]'s [=associated document=] is not a [=traversable navigable=], return false.
 1. Return true.
 
 <h2 id="storage-access-api-integration">Storage Access API Integration</h2>
@@ -191,8 +202,8 @@ Modify the [=determine the storage access policy=] algorithm by prepending the f
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |origin| be |settings|' [=environment settings object/origin=].
 1. Let |descriptor| be a newly created {{TopLevelStorageAccessPermissionDescriptor}} with <code>name</code> set to "<a permission><code>top-level-storage-access</code></a>" and with <code>requestedOrigin</code> set to |origin|.
-1. If |descriptor|'s [=permission state=] is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
-1. If |descriptor|'s [=permission state=] is [=permission/denied=], [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return.
+1. If |descriptor|'s [=permission state=] is [=permission/granted=], [=queue a global task=] on the [=permission task source=] given |global| to [=resolve=] |p|, and return.
+1. If |descriptor|'s [=permission state=] is [=permission/denied=], [=queue a global task=] on the [=permission task source=] given |global| to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return.
 
 <h2 id="privacy">Privacy considerations</h2>
 


### PR DESCRIPTION
This ensures that CORS + `use-credentials` is used in top-level subresource requests, and leaves open the possibility of an rSA call indicating embeddee opt-in for frames (with the latter point to be clarified in [a later effort](https://github.com/mreichhoff/requestStorageAccessForOrigin/issues/8) based on the outcome of per-frame discussions elsewhere).