### PR TITLE
Align the spec with new permission key generation algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -189,12 +189,11 @@ The requestStorageAccessFor API defines a [=powerful feature=] identified by the
   <dt>[=powerful feature/permission key generation algorithm=]</dt>
   <dd>
     <div algorithm='top-level-storage-access-key-generation'>
-    To generate a new [=permission key=] for the "<a permission><code>top-level-storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
-    1. Let |current origin| be |settings|' [=environment settings object/origin=].
-    1. If |current origin| is not [=same site=] with |settings|' [=top-level origin=], return null.
-    1. Return the result of [=obtain a site|obtaining a site=] from |settings|' [=top-level origin=].
+    To generate a new [=permission key=] for the "<a permission><code>top-level-storage-access</code></a>" feature, given an [=/origin=] |origin| and [=/origin=] |embedded origin|, run the following steps:
+    1. If |embedded origin| is not [=same site=] with |origin|, return null.
+    1. Return the result of [=obtain a site|obtaining a site=] from |origin|.
 
-        Note: the check for whether |settings|' [=environment settings object/origin=] is [=same site=] with |settings|' [=top-level origin=] is intended to disallow permission queries from cross-site frames.
+        Note: the check for whether |embedded origin| is [=same site=] with |origin| is intended to disallow permission queries from cross-site frames.
         This depends on the invariant that `top-level-storage-access` permission requests are only allowed in a [=top-level browsing context=]. As such, this check is only relevant in {{Permissions/query(permissionDesc)}}.
 
     </div>


### PR DESCRIPTION
To align with the change to the [permission key generation algorithm](https://w3c.github.io/permissions/#dfn-permission-key-generation-algorithm) that was modified in https://github.com/w3c/permissions/pull/468 (revised: https://github.com/w3c/permissions/pull/469) to the Permissions spec, requestStorageAccessFor API's algorithm should be updated to accept an origin and embedded origin, rather than an ESO.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jalonthomas/requestStorageAccessFor/pull/57.html" title="Last updated on Oct 17, 2025, 2:20 PM UTC (8b4136e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/requestStorageAccessFor/57/092b7ae...jalonthomas:8b4136e.html" title="Last updated on Oct 17, 2025, 2:20 PM UTC (8b4136e)">Diff</a>